### PR TITLE
Fall back to less secure options when a broken encryption chain is detected

### DIFF
--- a/bin/zelta
+++ b/bin/zelta
@@ -159,6 +159,7 @@ zelta_init() {
 
 	# `zfs send` defaults
 	: ${ZELTA_SEND_DEFAULT:="-L -c -e"}
+	: ${ZELTA_SEND_DECRYPTED:="-L -c"}
 	: ${ZELTA_SEND_RAW:="--raw"}
 	: ${ZELTA_SEND_NEW:="-p"}
 	: ${ZELTA_SEND_INTR:="1"}

--- a/doc/zelta-backup.md
+++ b/doc/zelta-backup.md
@@ -176,6 +176,9 @@ For precise control in a dataset tree with mixed types, override specific contex
 **--send-default** *"OPTIONS"*
 : `zfs send` options for **unencrypted** datasets (default: `-Lce`)
 
+**--send-decrypted** *"OPTIONS"*
+: `zfs send` options for encrypted datasets when raw incremental send is unavailable (default: `-Lc`)
+
 **--send-raw** *"OPTIONS"*
 : `zfs send` options for **encrypted** datasets (default: `-Lw`)
 

--- a/doc/zelta-options.7.md
+++ b/doc/zelta-options.7.md
@@ -116,6 +116,9 @@ The following options should be modified in the environment to ensure proper ins
 **SEND_DEFAULT**
 :   Options used for unencrypted filesystems and volumes. Defaults to `-Lce`.
 
+**SEND_DECRYPTED**
+:   Options used when an encrypted dataset must fall back to a decrypted incremental send. Defaults to `-Lc`.
+
 **SEND_RAW**
 :   Options used for encrypted datasets. Defaults to `-Lw`.
 

--- a/share/zelta/zelta-backup.awk
+++ b/share/zelta/zelta-backup.awk
@@ -160,6 +160,8 @@ function load_properties(ep,		_ds, _cmd_arr, _cmd, _cmd_id, _ds_suffix, _idx, _s
 			_prop_key = $2
 			_prop_val = ($3 == "off") ? "0" : $3
 			Dataset[_idx, _prop_key] = _prop_val
+			if ((ep == "SRC") && (_prop_key == "encryption") && (_prop_val != "0"))
+				DSTree["source_encrypted"] = 1
 
 			check_snapshot_needed(ep, _ds_suffix, _prop_key, _prop_val)
 			if (!_seen[_idx]++) {
@@ -186,7 +188,7 @@ function load_properties(ep,		_ds, _cmd_arr, _cmd, _cmd_id, _ds_suffix, _idx, _s
 
 # Imports a 'zelta match' row into DSPair and Dataset
 function parse_zelta_match_row(		_ds_suffix, _src_idx, _tgt_idx) {
-	if (NF == 5) {
+	if ((NF == 5) || (NF == 6)) {
 		# Indexes
 		_ds_suffix				= $1
 		_src_idx				= "SRC" SUBSEP _ds_suffix
@@ -195,9 +197,16 @@ function parse_zelta_match_row(		_ds_suffix, _src_idx, _tgt_idx) {
 		# 'zelta match' columns
 		DSList[++NumDS]				= _ds_suffix
 		DSPair[_ds_suffix, "match"]		= $2
-		Dataset[_src_idx, "next_snapshot"]	= $3
-		Dataset[_src_idx, "latest_snapshot"]	= $4
-		Dataset[_tgt_idx, "latest_snapshot"]	= $5
+		if (NF == 6) {
+			DSPair[_ds_suffix, "match_ivset"]	= $3
+			Dataset[_src_idx, "next_snapshot"]	= $4
+			Dataset[_src_idx, "latest_snapshot"]	= $5
+			Dataset[_tgt_idx, "latest_snapshot"]	= $6
+		} else {
+			Dataset[_src_idx, "next_snapshot"]	= $3
+			Dataset[_src_idx, "latest_snapshot"]	= $4
+			Dataset[_tgt_idx, "latest_snapshot"]	= $5
+		}
 	}
 	else {
 		if ($1 == "SOURCE_LIST_TIME:")		Summary["sourceListTime"] += $2
@@ -208,8 +217,9 @@ function parse_zelta_match_row(		_ds_suffix, _src_idx, _tgt_idx) {
 }
 
 # Run 'zfs match' and pass to parser
-function load_snapshot_deltas(_cmd_arr, _cmd) {
+function load_snapshot_deltas(_cmd_arr, _cmd, _cmd_id) {
 	FS = "\t"
+	_cmd_id = (DSTree["target_exists"] && DSTree["source_encrypted"]) ? "MATCH_IVSET" : "MATCH"
 	if (!DSTree["target_exists"])
 		_cmd_arr["command_prefix"]	= "ZELTA_TGT_ID=''"
 	if (Opt["DRYRUN"])
@@ -217,7 +227,7 @@ function load_snapshot_deltas(_cmd_arr, _cmd) {
 	# Depth is already in the environment
 	if (Opt["DEPTH"])
 		_cmd_arr["flags"]		= "-d" Opt["DEPTH"]
-	_cmd					= build_command("MATCH", _cmd_arr)
+	_cmd					= build_command(_cmd_id, _cmd_arr)
 	report(LOG_INFO, "checking replica deltas")
 	report(LOG_DEBUG, "`"_cmd"`")
 	_cmd 					= _cmd CAPTURE_OUTPUT
@@ -290,8 +300,8 @@ function validate_snapshots(		_i, _ds_suffix, _src_idx, _match, _src_exists, _sr
 }
 
 function compute_eligibility(           _i, _ds_suffix, _src_idx, _tgt_idx,
-                                        _has_next, _has_match, _tgt_exists,
-                                        _match, _src_latest, _tgt_latest) {
+					 _has_next, _has_match, _tgt_exists,
+					 _match, _src_latest, _tgt_latest) {
 	# Reset counters
 	DSTree["syncable"]         = 0
 	DSTree["needs_snapshot"]   = 0
@@ -389,6 +399,8 @@ function compute_eligibility(           _i, _ds_suffix, _src_idx, _tgt_idx,
 		# If we got here, we can sync
 		Action[_ds_suffix, "can_sync"] = 1
 		Action[_ds_suffix, "can_rotate"] = 1
+		if ((Opt["VERB"] != "replicate") && Dataset[_src_idx, "encryption"] && !DSPair[_ds_suffix, "match_ivset"])
+			Action[_ds_suffix, "send_decrypted"] = 1
 		DSTree["syncable"]++
 		DSTree["rotatable"]++
 	}
@@ -661,8 +673,13 @@ function get_send_command_flags(ds_suffix, idx,		_f, _idx, _flags, _flag_list) {
 		return Opt["SEND_OVERRIDE"]
 	if (Opt["VERB"] == "replicate")
 		_flag_list[++_f]	= Opt["SEND_REPLICATE"]
+	else if (Action[ds_suffix, "send_decrypted"]) {
+		if (!Action[ds_suffix, "warned_decrypted"]++)
+			report(LOG_WARNING, "raw incremental unavailable at " DSPair[ds_suffix, "match"] "; falling back to decrypted send: " Opt["SRC_DS"] ds_suffix)
+		_flag_list[++_f]	= Opt["SEND_DECRYPTED"]
+	}
 	else if (Dataset[idx,"encryption"])
-     	     _flag_list[++_f]		= Opt["SEND_RAW"]
+      	     _flag_list[++_f]		= Opt["SEND_RAW"]
 	else _flag_list[++_f]		= Opt["SEND_DEFAULT"]
 	_flags = arr_join(_flag_list)
 	return _flags

--- a/share/zelta/zelta-cmds.tsv
+++ b/share/zelta/zelta-cmds.tsv
@@ -13,6 +13,7 @@ PROPS	DEFAULT	zfs get	-Hpr -s local,none -t filesystem,volume -o name,property,v
 CREATE	DEFAULT	zfs create	-vupo canmount=noauto	ds
 SNAP	DEFAULT	zfs snapshot	-r	flags ds_snap
 MATCH		zelta ipc-run match	--time --log-mode=text --log-level=2 -Hpo relname,match,srcnext,srclast,tgtlast	flags
+MATCH_IVSET		zelta ipc-run match	--time --log-mode=text --log-level=2 -Hpo relname,match,matchivset,srcnext,srclast,tgtlast	flags
 MATCH_ORIGIN		zelta ipc-run match	--log-mode=text --log-level=2 -Hpo relname,match
 CLONE	DEFAULT	zfs clone	-p -o readonly=off	flags ds_snap ds
 SEND	SEND	zfs send	-P	flags intr_snap ds_snap

--- a/share/zelta/zelta-cols.tsv
+++ b/share/zelta/zelta-cols.tsv
@@ -1,6 +1,7 @@
 # COLNAME	# SYNONYMS	# TYPE	# DESCRIPTION	# DEPRECATION
 ds_suffix	relname,dssuffix	ds	Relative dataset name
 match	match	snap	Latest matching snapshot
+match_ivset	matchivset	text	IV set GUID for the selected match
 num_matches	nummatches,matches,count	num	Total number of matches
 xfer_size	xfersize,size	bytes	Unsynced data size based on snapshots
 xfer_num	xfernum,count,num	num	Unsynced snapshot count

--- a/share/zelta/zelta-match.awk
+++ b/share/zelta/zelta-match.awk
@@ -72,6 +72,10 @@ function add_written() {
 	return Opt["LIST_WRITTEN"] ? ",written,creation" : ""
 }
 
+function add_ivsetguid() {
+	return NeedMatchIVSet ? ",ivsetguid" : ""
+}
+
 # TO-DO: Add this feature to build_command()
 function wrap_time_cmd(cmd,		_cmd_part, _p) {
 	_cmd_part[++_p] = Opt["SH_COMMAND_PREFIX"]
@@ -88,7 +92,7 @@ function zfs_list_cmd(endpoint,		_ep, _ds, _remote, _cmd) {
 	_ep			= endpoint["ID"]
 	_ds			= endpoint["DS"]
 	_remote			= endpoint["REMOTE"]
-	_cmd_arr["props"]	= "name,guid" add_written()
+	_cmd_arr["props"]	= "name,guid" add_ivsetguid() add_written()
 	_cmd_arr["remote"]	= get_remote_cmd(endpoint)
 	_cmd_arr["ds"]		= rq(_remote, _ds)
 	if (Opt["DEPTH"])
@@ -161,13 +165,19 @@ function object_type(symbol) {
 }
 
 # Load each row into memory
-function process_row(ep,		_name, _guid, _written, _name_suffix, _ds_suffix, _savepoint,
-		     			_type, _ep_id, _ds_id, _ds_snap, _row_id, _tmp_arr, _num_snaps) {
+function process_row(ep,		_name, _guid, _ivsetguid, _written, _name_suffix, _ds_suffix, _savepoint,
+		     			_type, _ep_id, _ds_id, _ds_snap, _row_id, _tmp_arr, _num_snaps,
+					_field) {
 	# Read the row data
 	_name      = $1
 	_guid      = $2
-	_written   = $3
-	_creation  = $4
+	_field     = 2
+	if (NeedMatchIVSet)
+		_ivsetguid = $++_field
+	if (Opt["LIST_WRITTEN"]) {
+		_written   = $++_field
+		_creation  = $++_field
+	}
 
 	# Get the relative dataset suffix and then split to dataset and snapshot/bookmark name
 	_name_suffix		= substr(_name, ep["ds_length"])
@@ -198,6 +208,7 @@ function process_row(ep,		_name, _guid, _written, _name_suffix, _ds_suffix, _sav
 
 	Row[_row_id, "exists"]     = 1
 	Row[_row_id, "guid"]       = _guid
+	Row[_row_id, "ivsetguid"]  = _ivsetguid
 	Row[_row_id, "written"]    = _written
 	Row[_row_id, "creation"]   = _creation
 	Row[_row_id, "name"]       = _name
@@ -323,6 +334,8 @@ function validate_match(src_row, tgt_row, ds_suffix, savepoint, snap_idx) {
 	if (!DSPair[ds_suffix, "num_matches"]++) {
 		# TO-DO: Validate by filter
 		DSPair[ds_suffix, "match"] = savepoint
+		if (NeedMatchIVSet && Row[src_row, "ivsetguid"] && (Row[src_row, "ivsetguid"] == Row[tgt_row, "ivsetguid"]))
+			DSPair[ds_suffix, "match_ivset"] = Row[src_row, "ivsetguid"]
 		# Record match index for pruning
 		DSPair[ds_suffix, "match_idx"] = snap_idx
 	}
@@ -698,6 +711,8 @@ function load_columns(		_tsv, _key, _opt_list, _opt, _idx, _c, _default_proplist
 			_np = split(_prop_opts, _prop_opt_arr, S)
 			for (_p = 1; _p <= _np; _p++) {
 				PropList[++NumProps] = _prop_opt_arr[_p]
+				if (_prop_opt_arr[_p] == "match_ivset")
+					NeedMatchIVSet = 1
 			}
 		}
 	}

--- a/share/zelta/zelta-opts.tsv
+++ b/share/zelta/zelta-opts.tsv
@@ -61,6 +61,7 @@ policy,backup,replicate,sync,rotate	-h	USAGE		true		option '-h' is ambiguous; us
 policy,backup,replicate,sync	-I,--intermediate	SEND_INTR	INTERMEDIATE	true		intermediate mode: sync all possible snapshots
 policy,backup,replicate,sync	-i,--incremental	SEND_INTR	INTERMEDIATE	false		incremental mode: sync only the latest snapshots
 policy,backup,replicate,sync	--send-default	SEND_DEFAULT		set
+policy,backup,sync	--send-decrypted	SEND_DECRYPTED		set
 policy,backup,replicate,sync	--send-raw	SEND_RAW		set
 policy,backup,replicate,sync	--send-new	SEND_NEW		set
 policy,backup,replicate,sync	--recv-default	RECV_DEFAULT		set
@@ -103,4 +104,3 @@ legacy		SEND_OVERRIDE	SEND_FLAGS	set			SEND_FLAGS will be deprecated. See 'zelta
 legacy		RECV_OVERRIDE	RECEIVE_FLAGS	set			RECEIVE_FLAGS will be deprecated. See 'zelta help options' for new RECV options.
 legacy		REMOTE_SEND	REMOTE_SEND_COMMAND	set
 legacy		REMOTE_RECV	REMOTE_RECV_COMMAND	set
-

--- a/test/01_no_op_spec.sh
+++ b/test/01_no_op_spec.sh
@@ -34,11 +34,11 @@ Describe 'Zelta no-op command checks'
     		The status should be success
     		The output should include '+ zfs list'
     	End
-    	It 'respects single-dash parameters'
-    		When run command zelta match  -Hpvqn -X '*/swap' -d42 -o ds_suffix zelta-test-pool/test
-    		The status should be success
-    		The output should include '42'
-    	End
+	    	It 'respects single-dash parameters'
+	    		When run command zelta match  -Hpvqn -X '*/swap' -d42 -o match_ivset zelta-test-pool/test
+	    		The status should be success
+	    		The output should include '42'
+	    	End
     	It 'respects all parameters'
     		When run command zelta match  -Hpvqn -X '*/swap' -d42 -o ds_suffix --verbose --quiet --log-level 2 --log-mode=text --text --dryrun --depth 42 --exclude="@one,/two" zelta-test-pool/test zelta-test-pool/test-target
     		The status should be success

--- a/test/085_zelta_encrypted_raw_transition_spec.sh
+++ b/test/085_zelta_encrypted_raw_transition_spec.sh
@@ -19,6 +19,14 @@ enc_raw_init() {
 	fi
 }
 
+enc_create_key_for_src_and_tgt() {
+    dd if=/dev/urandom bs=32 count=1 of="$EncRawKey" 2>/dev/null
+    chmod 600 "$EncRawKey"
+    scp -p "$EncRawKey" "$SANDBOX_ZELTA_SRC_REMOTE:$EncRawKey"
+    scp -p "$EncRawKey" "$SANDBOX_ZELTA_TGT_REMOTE:$EncRawKey"	
+}
+
+
 enc_raw_cleanup() {
 	enc_raw_init
 	tgt_exec zfs destroy -r "$EncRawTgtDS" >/dev/null 2>&1 || :
@@ -31,7 +39,7 @@ enc_raw_cleanup() {
 enc_raw_setup() {
 	enc_raw_init
 	enc_raw_cleanup || return 1
-	src_exec dd if=/dev/urandom bs=32 count=1 of="$EncRawKey" >/dev/null 2>&1 || return 1
+	enc_create_key_for_src_and_tgt
 	src_exec zfs create -u -o encryption=on -o keyformat=raw -o "keylocation=file://$EncRawKey" "$EncRawSrcDS" || return 1
 	return 0
 }
@@ -48,7 +56,7 @@ enc_raw_snapshot_backup_raw() {
 }
 
 enc_raw_load_target_key() {
-	enc_raw_init
+        enc_raw_init
 	tgt_exec zfs load-key -L "file://$EncRawKey" "$EncRawTgtDS"
 }
 
@@ -67,7 +75,7 @@ enc_raw_snapshot_backup_fallback_nonraw() {
 Describe 'Encrypted raw-send transition'
 	Skip if 'SANDBOX_ZELTA_SRC_DS undefined' test -z "$SANDBOX_ZELTA_SRC_DS"
 	Skip if 'SANDBOX_ZELTA_TGT_DS undefined' test -z "$SANDBOX_ZELTA_TGT_DS"
-	Skip if 'requires shared source and target key path' test -n "$SANDBOX_ZELTA_SRC_REMOTE" -a -n "$SANDBOX_ZELTA_TGT_REMOTE" -a "$SANDBOX_ZELTA_SRC_REMOTE" != "$SANDBOX_ZELTA_TGT_REMOTE"
+	Skip if 'requires separate source and target remotes' test -z "$SANDBOX_ZELTA_SRC_REMOTE" -o -z "$SANDBOX_ZELTA_TGT_REMOTE" -o "$SANDBOX_ZELTA_SRC_REMOTE" = "$SANDBOX_ZELTA_TGT_REMOTE"
 
 	It 'creates an encrypted dataset with a key file'
 		When call enc_raw_setup

--- a/test/085_zelta_encrypted_raw_transition_spec.sh
+++ b/test/085_zelta_encrypted_raw_transition_spec.sh
@@ -1,0 +1,119 @@
+# Test encrypted raw-to-nonraw replication transition
+
+enc_raw_init() {
+	EncRawSuffix="/enc-raw-transition"
+	EncRawSrcDS="${SANDBOX_ZELTA_SRC_DS}${EncRawSuffix}"
+	EncRawTgtDS="${SANDBOX_ZELTA_TGT_DS}${EncRawSuffix}"
+	EncRawKey="/tmp/sandbox-zelta-test-key_${SANDBOX_ZELTA_PROCNUM}"
+
+	if [ -n "$SANDBOX_ZELTA_SRC_REMOTE" ]; then
+		EncRawSrcEP="${SANDBOX_ZELTA_SRC_REMOTE}:${EncRawSrcDS}"
+	else
+		EncRawSrcEP="$EncRawSrcDS"
+	fi
+
+	if [ -n "$SANDBOX_ZELTA_TGT_REMOTE" ]; then
+		EncRawTgtEP="${SANDBOX_ZELTA_TGT_REMOTE}:${EncRawTgtDS}"
+	else
+		EncRawTgtEP="$EncRawTgtDS"
+	fi
+}
+
+enc_raw_cleanup() {
+	enc_raw_init
+	tgt_exec zfs destroy -r "$EncRawTgtDS" >/dev/null 2>&1 || :
+	src_exec zfs destroy -r "$EncRawSrcDS" >/dev/null 2>&1 || :
+	tgt_exec rm -f "$EncRawKey" >/dev/null 2>&1 || :
+	src_exec rm -f "$EncRawKey" >/dev/null 2>&1 || :
+	return 0
+}
+
+enc_raw_setup() {
+	enc_raw_init
+	enc_raw_cleanup || return 1
+	src_exec dd if=/dev/urandom bs=32 count=1 of="$EncRawKey" >/dev/null 2>&1 || return 1
+	src_exec zfs create -u -o encryption=on -o keyformat=raw -o "keylocation=file://$EncRawKey" "$EncRawSrcDS" || return 1
+	return 0
+}
+
+enc_raw_initial_backup() {
+	enc_raw_init
+	zelta backup --log-level 4 "$EncRawSrcEP" "$EncRawTgtEP" 2>&1
+}
+
+enc_raw_snapshot_backup_raw() {
+	enc_raw_init
+	sleep 1
+	zelta backup --log-level 4 --snapshot "$EncRawSrcEP" "$EncRawTgtEP" 2>&1
+}
+
+enc_raw_load_target_key() {
+	enc_raw_init
+	tgt_exec zfs load-key -L "file://$EncRawKey" "$EncRawTgtDS"
+}
+
+enc_raw_snapshot_backup_override_nonraw() {
+	enc_raw_init
+	sleep 1
+	zelta backup --log-level 4 -Lc --snapshot "$EncRawSrcEP" "$EncRawTgtEP" 2>&1
+}
+
+enc_raw_snapshot_backup_fallback_nonraw() {
+	enc_raw_init
+	sleep 1
+	zelta backup --log-level 4 --snapshot "$EncRawSrcEP" "$EncRawTgtEP" 2>&1
+}
+
+Describe 'Encrypted raw-send transition'
+	Skip if 'SANDBOX_ZELTA_SRC_DS undefined' test -z "$SANDBOX_ZELTA_SRC_DS"
+	Skip if 'SANDBOX_ZELTA_TGT_DS undefined' test -z "$SANDBOX_ZELTA_TGT_DS"
+	Skip if 'requires shared source and target key path' test -n "$SANDBOX_ZELTA_SRC_REMOTE" -a -n "$SANDBOX_ZELTA_TGT_REMOTE" -a "$SANDBOX_ZELTA_SRC_REMOTE" != "$SANDBOX_ZELTA_TGT_REMOTE"
+
+	It 'creates an encrypted dataset with a key file'
+		When call enc_raw_setup
+		The status should be success
+	End
+
+	It 'replicates the first backup as raw'
+		When call enc_raw_initial_backup
+		The status should be success
+		The output should include 'syncing 1 datasets'
+		The output should include 'zfs send -P --raw'
+		The output should not include 'raw incremental unavailable'
+	End
+
+	It 'replicates the second backup with --snapshot as raw'
+		When call enc_raw_snapshot_backup_raw
+		The status should be success
+		The output should include 'snapshotting: @zelta_'
+		The output should include 'zfs send -P --raw -I'
+		The output should not include 'raw incremental unavailable'
+	End
+
+	It 'loads the target key'
+		When call enc_raw_load_target_key
+		The status should be success
+	End
+
+	It 'sends non-raw for --snapshot with -Lc after the target key is loaded'
+		When call enc_raw_snapshot_backup_override_nonraw
+		The status should be success
+		The output should include 'zfs send -P -Lc -Lc -I'
+		The output should not include 'zfs send -P --raw -I'
+		The output should not include 'raw incremental unavailable'
+	End
+
+	It 'complains and sends non-raw for later default --snapshot backups'
+		When call enc_raw_snapshot_backup_fallback_nonraw
+		The status should be success
+		The output should include 'raw incremental unavailable at @zelta_'
+		The output should include "falling back to decrypted send: ${SANDBOX_ZELTA_SRC_DS}/enc-raw-transition"
+		The output should include 'zfs send -P -L -c -I'
+		The output should not include 'zfs send -P --raw -I'
+	End
+
+	It 'cleans up the encrypted transition dataset'
+		When call enc_raw_cleanup
+		The status should be success
+	End
+End


### PR DESCRIPTION
If a user replicates an encrypted dataset non-raw with a loaded key on target, it will re-encrypt it. But this blocks the ability to use `--raw` in the future:
```sh
root@vault1.bts.djb0:~
# dd if=/dev/urandom bs=32 count=1 of=/tmp/sandbox-test-key
1+0 records in
1+0 records out
32 bytes transferred in 0.000095 secs (335799 bytes/sec)
root@vault1.bts.djb0:~
# zfs create -o encryption=on -o keyformat=raw -o keylocation=file:///tmp/sandbox-test-key rust07-scratch/treetop/encrypted
root@vault1.bts.djb0:~
# zelta backup rust07-scratch/treetop/encrypted rust07-scratch/treetop/encrypted2
source is written; snapshotting: @zelta_2026-04-11_03.21.33
syncing 1 datasets
70K sent, 1 streams received in 0.76 seconds 
root@vault1.bts.djb0:~ 1s
# zelta backup --snapshot rust07-scratch/treetop/encrypted rust07-scratch/treetop/encrypted2
snapshotting: @zelta_2026-04-11_03.23.21
syncing 1 datasets
dataset up-to-date
624B sent, 1 streams received in 0.62 seconds
root@vault1.bts.djb0:~ 1s
# zelta backup -Lc --snapshot rust07-scratch/treetop/encrypted rust07-scratch/treetop/encrypted2
snapshotting: @zelta_2026-04-11_03.23.32
syncing 1 datasets
error: cannot receive incremental stream: inherited key must be loaded: rust07-scratch/treetop/encrypted2 
### note I ran an intentional failure to demonstrate that the key needed to be loaded
root@vault1.bts.djb0:~ (255)
# zfs load-key -L file:///tmp/sandbox-test-key rust07-scratch/treetop/encrypted2
### successful load-key on target
root@vault1.bts.djb0:~
# zelta backup -Lc --snapshot rust07-scratch/treetop/encrypted rust07-scratch/treetop/encrypted2
snapshotting: @zelta_2026-04-11_03.25.06
syncing 1 datasets
dataset up-to-date
1K sent, 2 streams received in 0.76 seconds
root@vault1.bts.djb0:~ 1s
# zelta backup --snapshot rust07-scratch/treetop/encrypted rust07-scratch/treetop/encrypted2
snapshotting: @zelta_2026-04-11_03.25.12
syncing 1 datasets
error: cannot receive incremental stream: IV set guid mismatch. See the 'zfs receive' man page section: rust07-scratch/treetop/encrypted2 
```

This patch fixed the above final error so if the chain is broken, it drops options to the SEND_DECRYPTED zfs send flags, which are `--large-block --compressed`.