### PR TITLE
Backport #76: add support for including shell code in generated test

### DIFF
--- a/test/runners/test_generation/config/test_config_schema.yml
+++ b/test/runners/test_generation/config/test_config_schema.yml
@@ -22,10 +22,6 @@ properties:
   output_dir:
     type: string
     description: Directory for generated test files
-#  capture_output:
-#    type: boolean
-#    description: If true, capture stdout and stderr of all It clauses, used for test generation
-#    default: false
   example_list:
     type: array
     items:
@@ -45,6 +41,9 @@ definitions:
       tag:
         type: string
         description: shellspec tag to add to the generated Describe block
+      shell_code:
+        type: string
+        description: Muli-line entry interpreted as shell code include at top of Describe block
       hooks_list:
         type: array
         items:
@@ -103,6 +102,8 @@ definitions:
         type: string
         description: shellspec tag to add to the generated It block
       when_command:
+        type: string
+      output_clause:
         type: string
       allow_no_output:
         type: boolean

--- a/test/runners/test_generation/lib/ruby/shell_spec_gen.rb
+++ b/test/runners/test_generation/lib/ruby/shell_spec_gen.rb
@@ -11,7 +11,7 @@ module ShellSpecGen
 
   # `do` block binds to Data.define (defines methods on the parent); kept to satisfy RubyMine's RBS inference.
   #  TODO: remove `do` block when RubyMine supports RBS inference.
-  class Config < Data.define(:shellspec_name, :output_dir, :multi_desc, :multi_tag, :capture_output, :example_list, :shell_code) do
+  class Config < Data.define(:shellspec_name, :output_dir, :multi_desc, :multi_tag, :example_list, :shell_code) do
     def self.load_file(path)
       from_h(YAML.safe_load_file(path, symbolize_names: true))
     end
@@ -20,7 +20,6 @@ module ShellSpecGen
       config = new(
         shellspec_name: h.fetch(:shellspec_name),
         output_dir: h.fetch(:output_dir),
-        capture_output: h.fetch(:capture_output, false),
         multi_desc: h.fetch(:multi_desc, nil),
         multi_tag: h.fetch(:multi_tag, nil),
         example_list: h.fetch(:example_list).map { ExampleDefinition.from_h(it) },
@@ -35,11 +34,12 @@ module ShellSpecGen
   end # Data.define
   end # class Config
 
-  class ExampleDefinition < Data.define(:describe_desc, :tag, :hooks_list, :skip_if_list, :test_list) do
+  class ExampleDefinition < Data.define(:describe_desc, :tag, :shell_code, :hooks_list, :skip_if_list, :test_list) do
     def self.from_h(h)
       new(
         describe_desc: h.fetch(:describe_desc),
         tag: h.fetch(:tag, nil),
+        shell_code: h.fetch(:shell_code, nil),
         hooks_list: h.fetch(:hooks_list, []).map { Hook.from_h(it) },
         skip_if_list: h.fetch(:skip_if_list, []).map { SkipIf.from_h(it) },
         test_list: h.fetch(:test_list).map { TestDefinition.from_h(it) },
@@ -70,7 +70,7 @@ module ShellSpecGen
 
   class TestDefinition < Data.define(
     :test_name, :it_desc, :tag, :when_command,
-    :capture_output, :allow_no_output, :setup_scripts
+    :output_clause,:allow_no_output, :setup_scripts
   ) do
     def self.from_h(h)
       new(
@@ -78,7 +78,7 @@ module ShellSpecGen
         it_desc: h.fetch(:it_desc),
         tag: h.fetch(:tag, nil),
         when_command: h.fetch(:when_command),
-        capture_output: h.fetch(:capture_output, false),
+        output_clause: h.fetch(:output_clause, nil),
         allow_no_output: h.fetch(:allow_no_output, false),
         setup_scripts: h.fetch(:setup_scripts, []), # array of plain strings; no wrapper type
       )

--- a/test/runners/test_generation/lib/ruby/sig/spec_writer.rbs
+++ b/test/runners/test_generation/lib/ruby/sig/spec_writer.rbs
@@ -21,7 +21,7 @@ class SpecWriter
   def status_line: (String test_name, String indent) -> String
   def capture_output_clause: (String subdir, String test_name, String indent) -> String
   def matcher_func_name: (String test_name) -> String
-  def add_expected_output_clause: (File file, String test_name, bool allow_no_output, String indent) -> void
+  def add_expected_output_clause: (File file, String test_name, bool allow_no_output, String output_clause, String indent) -> void
   def append_it_clause: (File file, String indent, ShellSpecGen::TestDefinition test_def) -> void
   def create_test_matcher_functions: (File file, Array[ShellSpecGen::TestDefinition] test_list) -> void
   def process_tests: (File file, Array[ShellSpecGen::TestDefinition] test_list, String indent) -> void

--- a/test/runners/test_generation/lib/ruby/spec_writer.rb
+++ b/test/runners/test_generation/lib/ruby/spec_writer.rb
@@ -112,10 +112,11 @@ class SpecWriter
     "output_for_#{test_name}"
   end
 
-  def add_expected_output_clause(file, test_name, allow_no_output, indent)
+  def add_expected_output_clause(file, test_name, allow_no_output, output_clause, indent)
     # Check for stderr output
     func_name = matcher_func_name(test_name)
     file.puts "#{indent}    The output should satisfy #{func_name}" unless allow_no_output
+    file.puts "#{indent}    #{output_clause}" unless output_clause.nil?
     add_error_lines(file, test_name, indent)
     file.puts status_line(test_name, indent)
   end
@@ -143,7 +144,7 @@ class SpecWriter
   end
 
   def append_it_clause(file, indent, test_def)
-    test_def => { when_command:, test_name:, allow_no_output:, it_desc:, tag: }
+    test_def => { when_command:, test_name:, allow_no_output:, it_desc:, tag:, output_clause: }
 
     it_desc = Placeholders.substitute(it_desc, test_def, inclusions: [:when_command])
     file.puts "#{indent}  It \"#{it_desc.gsub('"', '\\"')}\"#{ tag ? " #{tag}" : ''}"
@@ -152,7 +153,7 @@ class SpecWriter
     if capture_output_only
       file.puts capture_output_clause(@paths.shellspec_name, test_name,indent)
     else
-      add_expected_output_clause(file, test_name, allow_no_output, indent)
+      add_expected_output_clause(file, test_name, allow_no_output, output_clause, indent)
     end
     # end It clause
     file.puts "#{indent}  End\n\n"
@@ -178,8 +179,13 @@ class SpecWriter
   end
 
   def process_example(file, example, indent)
-    example => { describe_desc:, tag:, skip_if_list:, hooks_list: }
+    example => { describe_desc:, tag:, skip_if_list:, hooks_list:, shell_code:}
     file.puts "#{indent}Describe '#{describe_desc}'#{ tag ? " #{tag}" : ''}"
+
+    unless shell_code.nil?
+      shell_code.each_line { |line| file.puts "#{indent}  #{line.chomp}" }
+      file.puts ''
+    end
 
     skip_if_list.each do |skip_item|
       file.puts "  Skip #{skip_item.condition}"
@@ -187,6 +193,7 @@ class SpecWriter
     file.puts '' unless skip_if_list.empty?
 
     # Add defined hooks
+    # TODO: consider removing hook.invocation, not used currently
     hooks_list.each do |hook|
       file.puts "  #{hook.name}  #{hook.command}"
     end


### PR DESCRIPTION
Backports #76 into `release/bsdcan2026`.

Cherry-picked squash commit `4ae1363` from `dev` (4 files, no conflicts):
- test/runners/test_generation/config/test_config_schema.yml
- test/runners/test_generation/lib/ruby/shell_spec_gen.rb
- test/runners/test_generation/lib/ruby/sig/spec_writer.rbs
- test/runners/test_generation/lib/ruby/spec_writer.rb

Original PR: https://github.com/bell-tower/zelta/pull/76