### PR TITLE
Fix/raw ipv6 as hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ All notable changes to Zelta will be documented in this file.
 - Dataset type detection with environment variables for each (TOP, NEW, FS, VOL, RAW, etc.).
 - Improved option hierarchy for `zelta policy`.
 - Fixed namespace configuration and repeated targets in `zelta policy`.
-- Workaround for GNU Awk 5.2.1 bug.
+- Workaround for GNU Awk 5.2.1/5.3.2 memory bug.
 - Resume token handling and other context-aware ZFS option handling.
 - Added `SYSTIME` option for mawk compatibility with JSON timestamps.
 

--- a/bin/zelta
+++ b/bin/zelta
@@ -128,17 +128,18 @@ zelta_init() {
 	fi
 
 	# Debian/Ubuntu awk bug workaround
+	# https://lists.gnu.org/archive/html/bug-gawk/2026-06/msg00067.html
 	if [ -z "$ZELTA_AWK" ]; then
 		_awk_ver=$(awk -V 2>/dev/null | head -n 1)
 		case "$_awk_ver" in
-		*"GNU Awk 5.2.1"*)
+		*"GNU Awk 5.2.1"*|*"GNU Awk 5.3.2"*)
 			if command -v mawk >/dev/null 2>&1; then
 				_good_awk=mawk
 			elif command -v original-awk >/dev/null 2>&1; then
 				_good_awk=original-awk
 			else
 				cat >&2 <<-EOF
-				warning: GNU Awk 5.2.1 has a serious memory bug; upgrade gawk or install original-awk/mawk:
+				warning: GNU Awk 5.2.1/5.3.2 has a serious memory bug; upgrade gawk or install original-awk/mawk:
 				  Ubuntu/Debian: apt install mawk
 				EOF
 			fi

--- a/share/zelta/zelta-args.awk
+++ b/share/zelta/zelta-args.awk
@@ -2,53 +2,21 @@
 #
 # zelta-args.awk: serialize common zelta arguments
 
-# Choose a hostname for logging
-function validate_host(host,		_hostname_cmd) {
-	if (!host || (host == "localhost"))
-		return Opt["HOSTNAME"]
-	else
-		return host
-}
-
-# TO-DO: Move to 'zelta-common.awk' as a generic endpoint calculator
-# Load and parse two endpoints, the source and target, sequentially
-# Create a set of variables from an scp-like host-dataset argument
-# [[user@]host:]dataset[@snapshot]
-function get_endpoint(		ep_type, _str_parts, _id, _remote ,_user, _host, _ds, _snap) {
-
+# Load SRC then TGT Opt fields from scp-like operands via load_endpoint()
+# [[user@]host:]dataset[@snapshot]  or  [[user@][ipv6]:]dataset[@snapshot]
+function get_endpoint(		ep_type, ep_arr) {
 	if (!NewOpt["SRC_ID"]) ep_type = "SRC_"
 	else if (!NewOpt["TGT_ID"]) ep_type = "TGT_"
 	else return
 
-	_id = $0				# ID is the user's endpoint string
-
-	# Find the connection info for ssh, '[user@]host'
-	if (/^[^ :\/]+:/) {
-		_remote = $0
-		sub(/:.*/, "", _remote)		# REMOTE is '[user@]host'
-		sub(/^[^ :\/]+:/,i "")		# Don't split(), $0 may have ':'
-		if (split(_remote, _str_parts, "@")==2) {
-			_user = _str_parts[1]	# USER from 'user@host'
-			_host = _str_parts[2]	# HOST
-		} else _host = _str_parts[1]	# HOST only
-		# Special case: If the DS or SNAP contains a ':' and our target is local, we
-		# have a work around: 'localhost:' _remote (with no user) gets cleared (so no ssh).
-		if (!_user && (_host == "localhost")) _remote = ""
-	}
-	if (split($0, _str_parts, "@") == 2) {
-		_snap = "@" _str_parts[2]
-	}
-	_ds = _str_parts[1]
-	if (!_user) { _user = ENVIRON["USER"] }	# USER may be useful for logging
-
-	# Validate and define the endpoint
-	if (! _ds) stop(1, "invalid endpoint '"_id"'")
-	NewOpt[ep_type "ID"]		= _id
-	NewOpt[ep_type "REMOTE"]	= _remote
-	NewOpt[ep_type "USER"]		= _user
-	NewOpt[ep_type "HOST"]		= validate_host(_host)
-	NewOpt[ep_type "DS"]		= _ds
-	NewOpt[ep_type "SNAP"]		= _snap
+	load_endpoint($0, ep_arr)
+	if (!ep_arr["DS"]) stop(1, "invalid endpoint '"$0"'")
+	NewOpt[ep_type "ID"]		= ep_arr["ID"]
+	NewOpt[ep_type "REMOTE"]	= ep_arr["REMOTE"]
+	NewOpt[ep_type "USER"]		= ep_arr["USER"]
+	NewOpt[ep_type "HOST"]		= ep_arr["HOST"]
+	NewOpt[ep_type "DS"]		= ep_arr["DS"]
+	NewOpt[ep_type "SNAP"]		= ep_arr["SNAP"]
 }
 
 function match_arg(arg, 	_flag) {

--- a/share/zelta/zelta-common.awk
+++ b/share/zelta/zelta-common.awk
@@ -33,8 +33,17 @@ function zelta_init(	_o, _prefix_re, _val) {
 function load_endpoint(ep, ep_arr,	_str_parts, _id, _remote ,_user, _host, _ds, _snap, _depth, _pool, _leaf) {
 	if (!ep) return
 	_id	= ep				# ID is the user's endpoint string
-	# Find the connection info for ssh, '[user@]host'
-	if (ep ~ /^[^ :\/]+:/) {
+	# Find the connection info for ssh: [user@]host: or [user@][ipv6]:
+	if (match(ep, /^([^\/: ]+@)?\[[^]]+\]:/)) {
+		_remote = substr(ep, 1, RLENGTH - 1)
+		ep = substr(ep, RLENGTH + 1)
+		# Strip IPv6 brackets: ssh wants user@addr, HOST is bare for prefixes
+		gsub(/[\[\]]/, "", _remote)
+		if (split(_remote, _str_parts, "@") == 2) {
+			_user = _str_parts[1]
+			_host = _str_parts[2]
+		} else _host = _remote
+	} else if (ep ~ /^[^ :\/]+:/) {
 		_remote	= ep
 		sub(/:.*/, "", _remote)		# REMOTE is '[user@]host'
 		sub(/^[^ :\/]+:/,"", ep)	# Don't split(), ep may have ':'


### PR DESCRIPTION
This allows IPv6 addressed endpoints in the rsync style [ip::address].

I can provide working prod examples if you need to see it in action for an example.

I also snuck in a tweak to add the Gawk warning for version 5.3.2, using the same mechanism as the existing 5.2.1 fix. This is for the Gawk bug here: https://lists.gnu.org/archive/html/bug-gawk/2026-06/msg00067.html